### PR TITLE
chore: Clean up package.jsons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-**/build
-.npmrc
+# Generated outputs
+**/lib/
 
 # Logs
 logs
@@ -43,6 +43,7 @@ jspm_packages/
 typings/
 
 # Optional npm cache directory
+.npmrc
 .npm
 
 # Optional eslint cache

--- a/front/context/package.json
+++ b/front/context/package.json
@@ -1,13 +1,17 @@
 {
   "name": "@substrate/context",
-  "author": "Parity Technologies <admin@parity.io>",
   "version": "0.1.5",
+  "author": "Parity Technologies <admin@parity.io>",
   "description": "Wrapper to connect React components to PolkadotJS Api",
+  "files":[
+    "lib"
+  ],
   "license": "Apache-2.0",
-  "main": "build/index.js",
+  "main": "lib/index.js",
   "publishConfig": {
     "access": "public"
   },
+  "repository":"https://github.com/yjkimjunior/Nomidot",
   "scripts": {
     "build": "tsc",
     "start": "yarn build --watch",

--- a/front/context/tsconfig.json
+++ b/front/context/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./lib"
   },
   "extends": "../../tsconfig",
   "include": ["./src"]

--- a/front/gatsby/package.json
+++ b/front/gatsby/package.json
@@ -1,9 +1,11 @@
 {
   "name": "gatsby-starter-default",
-  "private": true,
-  "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.5",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "author": "Parity Technologies <admin@parity.io>",
+  "description": "Staking Portal for Polkadot",
+  "license": "Apache-2.0",
+  "private": true,
+  "repository":"https://github.com/yjkimjunior/Nomidot",
   "dependencies": {
     "@types/react-helmet": "^5.0.14",
     "gatsby": "^2.17.10",
@@ -23,10 +25,6 @@
   "devDependencies": {
     "prettier": "^1.19.1"
   },
-  "keywords": [
-    "gatsby"
-  ],
-  "license": "MIT",
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
@@ -34,12 +32,5 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby-starter-default"
-  },
-  "bugs": {
-    "url": "https://github.com/gatsbyjs/gatsby/issues"
   }
 }

--- a/front/ui-components/package.json
+++ b/front/ui-components/package.json
@@ -3,11 +3,15 @@
   "version": "0.1.5",
   "author": "Parity Technologies <admin@parity.io>",
   "description": "UI components shared across Substrate Light UI",
+  "files":[
+    "lib"
+  ],
   "license": "Apache-2.0",
-  "main": "build/index.js",
+  "main": "lib/index.js",
   "publishConfig": {
     "access": "public"
   },
+  "repository":"https://github.com/yjkimjunior/Nomidot",
   "scripts": {
     "build": "tsc",
     "build-storybook": "build-storybook -c .storybook -o .out",
@@ -23,9 +27,6 @@
     "semantic-ui-react": "^0.88.1",
     "styled-components": "4.4.0"
   },
-  "peerDependencies": {
-    "react": "^16.9"
-  },
   "devDependencies": {
     "@storybook/addon-actions": "^5.2.5",
     "@storybook/addon-knobs": "^5.2.5",
@@ -34,5 +35,8 @@
     "@substrate/context": "^0.1.5",
     "@types/react-color": "^3.0.1",
     "@types/webpack-env": "^1.14.0"
+  },
+  "peerDependencies": {
+    "react": "^16.9"
   }
 }

--- a/front/ui-components/tsconfig.json
+++ b/front/ui-components/tsconfig.json
@@ -1,17 +1,9 @@
 {
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./lib"
   },
-  "rootDirs": [
-    "src",
-    "stories"
-  ],
+  "rootDirs": ["src", "stories"],
   "extends": "../../tsconfig",
-  "include": [
-    "./src"
-  ],
-  "types": [
-    "node",
-    "jest"
-  ]
+  "include": ["./src"],
+  "types": ["node", "jest"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,15 +2,10 @@
   "command": {
     "version": {
       "message": "chore(release): Publish %s"
-    },
-    "publish": {
-      "npmClient": "npm"
     }
   },
   "npmClient": "yarn",
-  "packages": [
-    "front/*"
-  ],
+  "packages": ["front/*"],
   "useWorkspaces": true,
   "version": "0.1.5"
 }

--- a/package.json
+++ b/package.json
@@ -1,25 +1,24 @@
 {
   "name": "nomidot",
-  "version": "1.0.0",
-  "main": "index.js",
-  "author": "",
+  "author": "Parity Technologies <admin@parity.io>",
+  "description": "Staking Portal for Polkadot",
   "license": "Apache-2.0",
+  "private": true,
+  "repository":"https://github.com/yjkimjunior/Nomidot",
+  "scripts": {
+    "prelerna:publish": "lerna exec yarn build --stream --scope @substrate/context --scope @substrate/ui-components",
+    "lerna:publish": "lerna version --conventional-commits && lerna publish from-git",
+    "lint": "tsc --noEmit",
+    "start": "cd ./front/gatsby && gatsby develop",
+    "storybook": "cd ./front/ui-components && yarn storybook"
+  },
   "workspaces": {
     "packages": [
       "front/*"
     ]
   },
-  "private": true,
   "devDependencies": {
     "lerna": "^3.18.4",
     "typescript": "^3.7.2"
-  },
-  "scripts": {
-    "lerna:build": "lerna exec yarn build --stream --scope @substrate/context --scope @substrate/ui-components",
-    "lerna:version": "lerna version --conventional-commits",
-    "lerna:publish": "lerna publish from-git",
-    "lint": "tsc --noEmit",
-    "start": "cd ./front/gatsby && gatsby develop",
-    "storybook": "cd ./front/ui-components && yarn storybook"
   }
 }


### PR DESCRIPTION
- same author, license etc in package.jsons
- outputs js files in `lib/` instead of `build/`. In this case, users would do:
```diff
import { NavButton } from '@substrate/ui-components';
- import { NavButton } from '@substrate/ui-components/build/NavButton';
+ import { NavButton } from '@substrate/ui-components/lib/NavButton';
```