### PR TITLE
refactor: Move ContextGate logic into ApiContext

### DIFF
--- a/front/context/src/AccountsContext.tsx
+++ b/front/context/src/AccountsContext.tsx
@@ -22,7 +22,7 @@ export function AccountsContextProvider(props: Props): React.ReactElement {
   );
 
   useEffect(() => {
-    const getInjected: () => void = async () => {
+    const getInjected = async (): Promise<void> => {
       await web3Enable('nomidot');
       const [injectedAccounts] = await Promise.all([
         web3Accounts().then((accounts): InjectedAccountExt[] =>

--- a/front/context/src/ApiContext.tsx
+++ b/front/context/src/ApiContext.tsx
@@ -2,9 +2,12 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import ApiRx from '@polkadot/api/rx';
+import { ApiRx, WsProvider } from '@polkadot/api';
 import { ChainProperties, Health } from '@polkadot/types/interfaces';
-import React from 'react';
+import { logger } from '@polkadot/util';
+import React, { useEffect, useState } from 'react';
+import { combineLatest } from 'rxjs';
+import { filter, switchMap } from 'rxjs/operators';
 
 export interface System {
   chain: string;
@@ -20,6 +23,110 @@ export interface ApiContextType {
   system: System; // Information about the chain
 }
 
+interface State {
+  isReady: boolean;
+  system: System;
+}
+
+const INIT_ERROR = new Error(
+  'Please wait for `isReady` before fetching this property'
+);
+
+const DISCONNECTED_STATE_PROPERTIES = {
+  isReady: false,
+  system: {
+    get chain(): never {
+      throw INIT_ERROR;
+    },
+    get health(): never {
+      throw INIT_ERROR;
+    },
+    get name(): never {
+      throw INIT_ERROR;
+    },
+    get properties(): never {
+      throw INIT_ERROR;
+    },
+    get version(): never {
+      throw INIT_ERROR;
+    },
+  },
+};
+
+// Hardcode default to Kusama
+const WS_URL = 'wss://kusama-rpc.polkadot.io/';
+
+const l = logger('api-context');
+
+const api = new ApiRx({ provider: new WsProvider(WS_URL) });
+
 export const ApiContext: React.Context<ApiContextType> = React.createContext(
   {} as ApiContextType
 );
+
+export interface ApiContextProviderProps {
+  children?: React.ReactNode;
+  loading?: React.ReactNode;
+}
+
+export function ApiContextProvider(
+  props: ApiContextProviderProps = { children: null, loading: null }
+): React.ReactElement {
+  const { children, loading } = props;
+  const [state, setState] = useState<State>(DISCONNECTED_STATE_PROPERTIES);
+  const { isReady, system } = state;
+
+  useEffect(() => {
+    // Block the UI when disconnected
+    api.isConnected.pipe(filter(isConnected => !isConnected)).subscribe(() => {
+      setState(DISCONNECTED_STATE_PROPERTIES);
+    });
+
+    // We want to fetch all the information again each time we reconnect. We
+    // might be connecting to a different node, or the node might have changed
+    // settings.
+    api.isReady
+      .pipe(
+        switchMap(() =>
+          combineLatest([
+            api.rpc.system.chain(),
+            api.rpc.system.health(),
+            api.rpc.system.name(),
+            api.rpc.system.properties(),
+            api.rpc.system.version(),
+          ])
+        )
+      )
+      .subscribe(([chain, health, name, properties, version]) => {
+        l.log(`Api connected to ${WS_URL}`);
+        l.log(
+          `Api ready, connected to chain "${chain}" with properties ${JSON.stringify(
+            properties
+          )}`
+        );
+
+        setState({
+          isReady: true,
+          system: {
+            chain: chain.toString(),
+            health,
+            name: name.toString(),
+            properties,
+            version: version.toString(),
+          },
+        });
+      });
+  }, []);
+
+  return (
+    <ApiContext.Provider
+      value={{
+        api: api,
+        isReady,
+        system,
+      }}
+    >
+      {state.isReady ? children : loading}
+    </ApiContext.Provider>
+  );
+}

--- a/front/gatsby/src/ContextGate.tsx
+++ b/front/gatsby/src/ContextGate.tsx
@@ -2,123 +2,27 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { ApiRx, WsProvider } from '@polkadot/api';
-import { logger } from '@polkadot/util';
 import {
   AccountsContextProvider,
   AlertsContextProvider,
-  ApiContext,
+  ApiContextProvider,
   StakingContextProvider,
-  System,
   TxQueueContextProvider,
 } from '@substrate/context/src';
-import React, { useEffect, useState } from 'react';
-import { combineLatest } from 'rxjs';
-import { filter, switchMap } from 'rxjs/operators';
+import React from 'react';
 
-interface State {
-  isReady: boolean;
-  system: System;
-}
-
-const INIT_ERROR = new Error(
-  'Please wait for `isReady` before fetching this property'
-);
-
-const DISCONNECTED_STATE_PROPERTIES = {
-  isReady: false,
-  system: {
-    get chain(): never {
-      throw INIT_ERROR;
-    },
-    get health(): never {
-      throw INIT_ERROR;
-    },
-    get name(): never {
-      throw INIT_ERROR;
-    },
-    get properties(): never {
-      throw INIT_ERROR;
-    },
-    get version(): never {
-      throw INIT_ERROR;
-    },
-  },
-};
-
-// Hardcode default to Kusama
-const WS_URL = 'wss://kusama-rpc.polkadot.io/';
-
-const l = logger('context');
-
-const api = new ApiRx({ provider: new WsProvider(WS_URL) });
-
-export function ContextGate(props: {
+export function ContextGate({
+  children,
+}: {
   children: React.ReactNode;
 }): React.ReactElement {
-  const { children } = props;
-  const [state, setState] = useState<State>(DISCONNECTED_STATE_PROPERTIES);
-  const { isReady, system } = state;
-
-  useEffect(() => {
-    // Block the UI when disconnected
-    api.isConnected.pipe(filter(isConnected => !isConnected)).subscribe(() => {
-      setState(DISCONNECTED_STATE_PROPERTIES);
-    });
-
-    // We want to fetch all the information again each time we reconnect. We
-    // might be connecting to a different node, or the node might have changed
-    // settings.
-    api.isConnected
-      .pipe(
-        filter(isConnected => !!isConnected),
-        // API needs to be ready to be able to use RPCs; connected isn't enough
-        switchMap(() => api.isReady),
-        switchMap(() =>
-          combineLatest([
-            api.rpc.system.chain(),
-            api.rpc.system.health(),
-            api.rpc.system.name(),
-            api.rpc.system.properties(),
-            api.rpc.system.version(),
-          ])
-        )
-      )
-      .subscribe(([chain, health, name, properties, version]) => {
-        l.log(`Api connected to ${WS_URL}`);
-        l.log(
-          `Api ready, connected to chain "${chain}" with properties ${JSON.stringify(
-            properties
-          )}`
-        );
-
-        setState({
-          ...state,
-          isReady: true,
-          system: {
-            chain: chain.toString(),
-            health,
-            name: name.toString(),
-            properties,
-            version: version.toString(),
-          },
-        });
-      });
-  }, [state]);
-
   return (
     <AlertsContextProvider>
       <AccountsContextProvider>
         <TxQueueContextProvider>
-          <ApiContext.Provider
-            value={{
-              api: api,
-              isReady,
-              system,
-            }}
-          >
+          <ApiContextProvider>
             <StakingContextProvider>{children}</StakingContextProvider>
-          </ApiContext.Provider>
+          </ApiContextProvider>
         </TxQueueContextProvider>
       </AccountsContextProvider>
     </AlertsContextProvider>

--- a/front/ui-components/src/index.ts
+++ b/front/ui-components/src/index.ts
@@ -4,18 +4,28 @@
 
 // We export these ones as-is from SUI
 export {
-  Dropdown, DropdownProps,
-  Form, FormProps,
-  Grid, GridProps,
-  List, ListProps,
-  Image, ImageProps,
-  Menu, MenuProps,
-  Message, MessageProps,
-  Segment, SegmentProps,
-  Sidebar, SidebarProps,
-  Step, StepProps,
-  Table, TableProps,
-  Transition, TransitionGroup
+  DropdownProps,
+  Form,
+  FormProps,
+  Grid,
+  GridProps,
+  List,
+  ListProps,
+  Image,
+  ImageProps,
+  MenuProps,
+  Message,
+  MessageProps,
+  Segment,
+  SegmentProps,
+  Sidebar,
+  SidebarProps,
+  Step,
+  StepProps,
+  Table,
+  TableProps,
+  Transition,
+  TransitionGroup,
 } from 'semantic-ui-react';
 
 export * from './Accordion';


### PR DESCRIPTION
The `api` object should be populated by the ApiContext (and not the ContextGate). This way, in light-ui, I can use the same ApiContext too.

Added a loading prop on `ApiContextProvider`: `<ApiContextProvider loading='HELLO'` />` will show HELLO while the api is loading.