### PR TITLE
fix: Add forgotten Dropdown in ui-components

### DIFF
--- a/front/ui-components/src/index.ts
+++ b/front/ui-components/src/index.ts
@@ -4,6 +4,7 @@
 
 // We export these ones as-is from SUI
 export {
+  Dropdown,
   DropdownProps,
   Form,
   FormProps,


### PR DESCRIPTION
Just realized that while refactoring light-ui