### PR TITLE
fix: Allow importing without src/ directory

### DIFF
--- a/front/gatsby/gatsby-node.js
+++ b/front/gatsby/gatsby-node.js
@@ -1,7 +1,22 @@
+/* eslint-disable */
+
+const path = require('path');
+
 /**
  * Implement Gatsby's Node APIs in this file.
  *
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
-/* eslint-disable */
-// You can delete this file if you're not using it
+exports.onCreateWebpackConfig = function({ actions }) {
+  actions.setWebpackConfig({
+    resolve: {
+      alias: {
+        '@substrate/context': path.resolve(__dirname, '../context/src'),
+        '@substrate/ui-components': path.resolve(
+          __dirname,
+          '../ui-components/src'
+        ),
+      },
+    },
+  });
+};

--- a/front/gatsby/src/ContextGate.tsx
+++ b/front/gatsby/src/ContextGate.tsx
@@ -8,7 +8,7 @@ import {
   ApiContextProvider,
   StakingContextProvider,
   TxQueueContextProvider,
-} from '@substrate/context/src';
+} from '@substrate/context';
 import React from 'react';
 
 export function ContextGate({

--- a/front/gatsby/src/components/layout.tsx
+++ b/front/gatsby/src/components/layout.tsx
@@ -7,7 +7,7 @@
 
 import './layout.css';
 
-import { Container } from '@substrate/ui-components/src';
+import { Container } from '@substrate/ui-components';
 import { graphql, useStaticQuery } from 'gatsby';
 import React from 'react';
 

--- a/front/gatsby/src/pages/home.tsx
+++ b/front/gatsby/src/pages/home.tsx
@@ -2,11 +2,8 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Header } from '@substrate/ui-components/src';
-// import { ApiContext } from '@substrate/context/src';
+import { Header } from '@substrate/ui-components';
 import React from 'react';
-
-// import { ContextGate } from '../ContextGate';
 
 export function HomePage(): React.ReactElement {
   return (

--- a/front/gatsby/src/pages/index.tsx
+++ b/front/gatsby/src/pages/index.tsx
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { ApiContext, ApiContextType } from '@substrate/context/src';
+import { ApiContext, ApiContextType } from '@substrate/context';
 import React from 'react';
 
 import Layout from '../components/layout';
@@ -11,8 +11,6 @@ import { ContextGate } from '../ContextGate';
 import { Onboarding } from './onboarding';
 
 function IndexPage(): React.ReactElement {
-  // const { injectedAccounts } = useContext(AccountsContext);
-
   return (
     <ContextGate>
       <ApiContext.Consumer>

--- a/front/gatsby/src/pages/onboarding.tsx
+++ b/front/gatsby/src/pages/onboarding.tsx
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { RouteComponentProps } from '@reach/router';
-import { AccountsContext } from '@substrate/context/src';
+import { AccountsContext } from '@substrate/context';
 import {
   AccountsList,
   Breadcrumbs,
@@ -11,7 +11,7 @@ import {
   Modal,
   polkadotOfficialTheme,
   Transition,
-} from '@substrate/ui-components/src';
+} from '@substrate/ui-components';
 import React, { useContext } from 'react';
 
 const ONBOARDING_STEPS = ['stash', 'controller'];
@@ -19,8 +19,6 @@ const ONBOARDING_STEPS = ['stash', 'controller'];
 // eslint-disable-next-line
 export const Onboarding = (props: RouteComponentProps): React.ReactElement => {
   const { injectedAccounts } = useContext(AccountsContext);
-  // const [stash, setStash] = useState();
-  // const [controller, setController] = useState();
 
   return (
     <Transition animation='scale' duration={500} transitionOnMount visible>

--- a/front/gatsby/tsconfig.json
+++ b/front/gatsby/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig"
+}

--- a/front/ui-components/src/AccountsList.tsx
+++ b/front/ui-components/src/AccountsList.tsx
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { InjectedAccountExt } from '@substrate/context/src';
+import { InjectedAccountExt } from '@substrate/context';
 import React from 'react';
 import List from 'semantic-ui-react/dist/commonjs/elements/List/List';
 

--- a/front/ui-components/src/stateful/Balance.tsx
+++ b/front/ui-components/src/stateful/Balance.tsx
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { DerivedBalances, DerivedStaking } from '@polkadot/api-derive/types';
-import { ApiContext } from '@substrate/context/src';
+import { ApiContext } from '@substrate/context';
 import React, { useContext, useEffect, useState } from 'react';
 import { combineLatest, of } from 'rxjs';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,16 @@
   "exclude": ["node_modules", "public", ".cache"],
   "include": ["**/*.js", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
+    "baseUrl": ".",
     "declaration": true,
     "downlevelIteration": true,
     "esModuleInterop": true,
     "jsx": "react",
     "lib": ["dom", "esnext"],
+    "paths": {
+      "@substrate/context": ["front/context/src"],
+      "@substrate/ui-components": ["front/ui-components/src"]
+    },
     "skipLibCheck": true,
     "strict": true,
     "target": "es5"


### PR DESCRIPTION
fixes #25 

```diff
- import A from '@substrate/context/src'
+ import A from '@substrate/context'
```

Still publishes everything in the `lib/` folder